### PR TITLE
Auto height for non mobile menu

### DIFF
--- a/scss/_non-mobile.scss
+++ b/scss/_non-mobile.scss
@@ -16,6 +16,10 @@
         &:not(:checked) ~.luxbar-menu {
             overflow: visible;
         }
+        
+        &:checked ~.luxbar-menu {
+          height: auto;
+        }
     }
 
     .luxbar-menu {


### PR DESCRIPTION
Set height back to auto when mobile menu is no longer displayed.
https://github.com/balzss/luxbar/issues/15