### PR TITLE
Fix lint warnings, add missing z-index for other modes

### DIFF
--- a/scss/_global-variables.scss
+++ b/scss/_global-variables.scss
@@ -3,4 +3,4 @@ $luxbar-padding: 18px 24px 18px 24px;
 $luxbar-transition: .6s ease;
 $hamburger-line-height: 2px;
 $hamburger-width: 26px;
-$luxbar-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
+$luxbar-shadow: 0 1px 3px rgba(#000, 0.12), 0 1px 2px rgba(#000 ,0.24);

--- a/scss/_global-variables.scss
+++ b/scss/_global-variables.scss
@@ -3,4 +3,4 @@ $luxbar-padding: 18px 24px 18px 24px;
 $luxbar-transition: .6s ease;
 $hamburger-line-height: 2px;
 $hamburger-width: 26px;
-$luxbar-shadow: 0 1px 3px rgba(#000, 0.12), 0 1px 2px rgba(#000 ,0.24);
+$luxbar-shadow: 0 1px 3px rgba(#000, .12), 0 1px 2px rgba(#000, .24);

--- a/scss/_hamburger-animation.scss
+++ b/scss/_hamburger-animation.scss
@@ -12,6 +12,7 @@
                     }
                 }
             }
+
             .luxbar-hamburger-spin {
                 span {
                     &::before {

--- a/scss/_mobile.scss
+++ b/scss/_mobile.scss
@@ -27,7 +27,8 @@
 }
 
 .luxbar-menu-left {
-    .luxbar-navigation, .luxbar-header {
+    .luxbar-navigation,
+    .luxbar-header {
         justify-content: flex-start;
     }
 }
@@ -132,7 +133,7 @@
         min-width: 100%;
     }
 
-    & > a {
+    > a {
         &::after {
             $expand-arrow-height: 5px;
 
@@ -146,7 +147,7 @@
         }
     }
 
-    & > ul {
+    > ul {
         display: block;
         overflow-x: hidden;
         list-style: none;

--- a/scss/_modes.scss
+++ b/scss/_modes.scss
@@ -2,6 +2,7 @@
     width: 100%;
     position: relative;
     box-shadow: $luxbar-shadow;
+    z-index: 1000;
 }
 
 .luxbar-static {
@@ -10,6 +11,7 @@
     position: absolute;
     top: 0;
     left: 0;
+    z-index: 1000;
 
     .luxbar-checkbox {
         &:checked ~.luxbar-menu {

--- a/scss/_non-mobile.scss
+++ b/scss/_non-mobile.scss
@@ -12,7 +12,7 @@
         &:not(:checked) ~.luxbar-menu {
             overflow: visible;
         }
-        
+
         &:checked ~.luxbar-menu {
           height: $luxbar-height;
         }
@@ -39,7 +39,7 @@
             padding: 0;
         }
 
-        & > ul {
+        > ul {
             display: none;
 
             .luxbar-item {

--- a/scss/_themes.scss
+++ b/scss/_themes.scss
@@ -1,4 +1,4 @@
-/******* color variables *******/
+// ******* color variables *******
 $dark-bg: #212121;
 $dark-hl: #424242;
 $dark-fg: #fff;
@@ -35,7 +35,7 @@ $material-brown-bg: #3e2723;
 $material-brown-hl: #4e342e;
 $material-brown-fg: #fff;
 
-/******* default dark *******/
+// ******* default dark *******
 .luxbar-menu-dark,
 .luxbar-menu-dark .dropdown ul {
     background-color: $dark-bg;
@@ -57,7 +57,7 @@ $material-brown-fg: #fff;
     }
 }
 
-/******* default light *******/
+// ******* default light *******
 .luxbar-menu-light,
 .luxbar-menu-light .dropdown ul {
     background-color: $light-bg;
@@ -79,7 +79,7 @@ $material-brown-fg: #fff;
     }
 }
 
-/******* default material-red *******/
+// ******* default material-red *******
 .luxbar-menu-material-red,
 .luxbar-menu-material-red .dropdown ul {
     background-color: $material-red-bg;
@@ -101,7 +101,7 @@ $material-brown-fg: #fff;
     }
 }
 
-/******* default material-indigo *******/
+// ******* default material-indigo *******
 .luxbar-menu-material-indigo,
 .luxbar-menu-material-indigo .dropdown ul {
     background-color: $material-indigo-bg;
@@ -123,7 +123,7 @@ $material-brown-fg: #fff;
     }
 }
 
-/******* default material-green *******/
+// ******* default material-green *******
 .luxbar-menu-material-green,
 .luxbar-menu-material-green .dropdown ul {
     background-color: $material-green-bg;
@@ -145,7 +145,7 @@ $material-brown-fg: #fff;
     }
 }
 
-/******* default material-amber *******/
+// ******* default material-amber *******
 .luxbar-menu-material-amber,
 .luxbar-menu-material-amber .dropdown ul {
     background-color: $material-amber-bg;
@@ -167,7 +167,7 @@ $material-brown-fg: #fff;
     }
 }
 
-/******* default material-brown *******/
+// ******* default material-brown *******
 .luxbar-menu-material-brown,
 .luxbar-menu-material-brown .dropdown ul {
     background-color: $material-brown-bg;
@@ -189,7 +189,7 @@ $material-brown-fg: #fff;
     }
 }
 
-/******* default material-bluegrey *******/
+// ******* default material-bluegrey *******
 .luxbar-menu-material-bluegrey,
 .luxbar-menu-material-bluegrey .dropdown ul {
     background-color: $material-bluegrey-bg;
@@ -211,7 +211,7 @@ $material-brown-fg: #fff;
     }
 }
 
-/******* default material-cyan *******/
+// ******* default material-cyan *******
 .luxbar-menu-material-cyan,
 .luxbar-menu-material-cyan .dropdown ul {
     background-color: $material-cyan-bg;


### PR DESCRIPTION
Hello! Here are some fixes I found. Please merge if you see fit. With static and default modes navigation didn't open at all for me, because of missing z-indexes.