### PR TITLE
Add $luxbar-css-prefix variable to allow user for choose class names freely

### DIFF
--- a/scss/_global-variables.scss
+++ b/scss/_global-variables.scss
@@ -4,3 +4,4 @@ $luxbar-transition: .6s ease;
 $hamburger-line-height: 2px;
 $hamburger-width: 26px;
 $luxbar-shadow: 0 1px 3px rgba(#000, .12), 0 1px 2px rgba(#000, .24);
+$luxbar-css-prefix: 'luxbar' !default;

--- a/scss/_hamburger-animation.scss
+++ b/scss/_hamburger-animation.scss
@@ -1,7 +1,7 @@
-.luxbar-checkbox {
+.#{$luxbar-css-prefix}-checkbox {
     &:checked {
-        + .luxbar-menu {
-            .luxbar-hamburger-doublespin {
+        + .#{$luxbar-css-prefix}-menu {
+            .#{$luxbar-css-prefix}-hamburger-doublespin {
                 span {
                     &::before {
                         transform: rotate(225deg);
@@ -13,7 +13,7 @@
                 }
             }
 
-            .luxbar-hamburger-spin {
+            .#{$luxbar-css-prefix}-hamburger-spin {
                 span {
                     &::before {
                         transform: rotate(45deg);

--- a/scss/_mobile.scss
+++ b/scss/_mobile.scss
@@ -27,14 +27,14 @@
 }
 
 .#{$luxbar-css-prefix}-menu-left {
-    .luxbar-navigation,
-    .luxbar-header {
+    .#{$luxbar-css-prefix}-navigation,
+    .#{$luxbar-css-prefix}-header {
         justify-content: flex-start;
     }
 }
 
 .#{$luxbar-css-prefix}-menu-right {
-    .luxbar-hamburger {
+    .#{$luxbar-css-prefix}-hamburger {
         margin-left: auto;
     }
 }
@@ -104,18 +104,18 @@
 .#{$luxbar-css-prefix}-checkbox {
     display: none;
 
-    &:not(:checked) ~.luxbar-menu {
+    &:not(:checked) ~.#{$luxbar-css-prefix}-menu {
         overflow: hidden;
         height: $luxbar-height;
     }
 
-    &:checked ~.luxbar-menu {
+    &:checked ~.#{$luxbar-css-prefix}-menu {
         transition: height $luxbar-transition;
         height: 100vh;
         overflow: auto;
 
         li {
-            .luxbar-hamburger {
+            .#{$luxbar-css-prefix}-hamburger {
                 @extend %hamburger-lines;
             }
         }

--- a/scss/_mobile.scss
+++ b/scss/_mobile.scss
@@ -18,7 +18,7 @@
     }
 }
 
-.luxbar-header {
+.#{$luxbar-css-prefix}-header {
     display: flex;
     flex-direction: row;
     justify-content: space-between;
@@ -26,31 +26,31 @@
     height: $luxbar-height;
 }
 
-.luxbar-menu-left {
+.#{$luxbar-css-prefix}-menu-left {
     .luxbar-navigation,
     .luxbar-header {
         justify-content: flex-start;
     }
 }
 
-.luxbar-menu-right {
+.#{$luxbar-css-prefix}-menu-right {
     .luxbar-hamburger {
         margin-left: auto;
     }
 }
 
-.luxbar-brand {
+.#{$luxbar-css-prefix}-brand {
     font-size: 1.6em;
     padding: $luxbar-padding;
 }
 
-.luxbar-menu {
+.#{$luxbar-css-prefix}-menu {
     min-height: $luxbar-height;
     transition: $luxbar-transition;
     width: 100%;
 }
 
-.luxbar-navigation {
+.#{$luxbar-css-prefix}-navigation {
     display: flex;
     flex-direction: column;
     list-style: none;
@@ -58,8 +58,8 @@
     margin: 0;
 }
 
-.luxbar-menu,
-.luxbar-item {
+.#{$luxbar-css-prefix}-menu,
+.#{$luxbar-css-prefix}-item {
     a {
         text-decoration: none;
         color: inherit;
@@ -67,7 +67,7 @@
     }
 }
 
-.luxbar-item {
+.#{$luxbar-css-prefix}-item {
     height: $luxbar-height;
 
     a {
@@ -76,7 +76,7 @@
     }
 }
 
-.luxbar-hamburger {
+.#{$luxbar-css-prefix}-hamburger {
     padding: $luxbar-padding;
     position: relative;
     cursor: pointer;
@@ -101,7 +101,7 @@
     }
 }
 
-.luxbar-checkbox {
+.#{$luxbar-css-prefix}-checkbox {
     display: none;
 
     &:not(:checked) ~.luxbar-menu {
@@ -153,7 +153,7 @@
         list-style: none;
         padding: 0;
 
-        .luxbar-item {
+        .#{$luxbar-css-prefix}-item {
             min-width: 100%;
             height: $luxbar-height / 2;
             padding: 5px 10px 5px 40px;

--- a/scss/_modes.scss
+++ b/scss/_modes.scss
@@ -1,11 +1,11 @@
-.luxbar-default {
+.#{$luxbar-css-prefix}-default {
     width: 100%;
     position: relative;
     box-shadow: $luxbar-shadow;
     z-index: 1000;
 }
 
-.luxbar-static {
+.#{$luxbar-css-prefix}-static {
     box-shadow: $luxbar-shadow;
     width: 100%;
     position: absolute;
@@ -13,14 +13,14 @@
     left: 0;
     z-index: 1000;
 
-    .luxbar-checkbox {
+    .#{$luxbar-css-prefix}-checkbox {
         &:checked ~.luxbar-menu {
             position: absolute;
         }
     }
 }
 
-.luxbar-fixed {
+.#{$luxbar-css-prefix}-fixed {
     width: 100%;
     position: fixed;
     top: 0;
@@ -29,7 +29,7 @@
     box-shadow: $luxbar-shadow;
 }
 
-.luxbar-fixed-bottom {
+.#{$luxbar-css-prefix}-fixed-bottom {
     width: 100%;
     position: fixed;
     bottom: 0;

--- a/scss/_modes.scss
+++ b/scss/_modes.scss
@@ -14,7 +14,7 @@
     z-index: 1000;
 
     .#{$luxbar-css-prefix}-checkbox {
-        &:checked ~.luxbar-menu {
+        &:checked ~.#{$luxbar-css-prefix}-menu {
             position: absolute;
         }
     }

--- a/scss/_non-mobile.scss
+++ b/scss/_non-mobile.scss
@@ -1,31 +1,31 @@
 @media screen and (min-width: 768px) {
-    .luxbar-navigation {
+    .#{$luxbar-css-prefix}-navigation {
         flex-flow: row;
         justify-content: flex-end;
     }
 
-    .luxbar-hamburger {
+    .#{$luxbar-css-prefix}-hamburger {
         display: none;
     }
 
-    .luxbar-checkbox {
-        &:not(:checked) ~.luxbar-menu {
+    .#{$luxbar-css-prefix}-checkbox {
+        &:not(:checked) ~.#{$luxbar-css-prefix}-menu {
             overflow: visible;
         }
 
-        &:checked ~.luxbar-menu {
+        &:checked ~.#{$luxbar-css-prefix}-menu {
           height: $luxbar-height;
         }
     }
 
-    .luxbar-menu {
-        .luxbar-item {
+    .#{$luxbar-css-prefix}-menu {
+        .#{$luxbar-css-prefix}-item {
             border-top: 0;
         }
 
     }
 
-    .luxbar-menu-right .luxbar-header {
+    .#{$luxbar-css-prefix}-menu-right .#{$luxbar-css-prefix}-header {
         margin-right: auto;
     }
 
@@ -42,7 +42,7 @@
         > ul {
             display: none;
 
-            .luxbar-item {
+            .#{$luxbar-css-prefix}-item {
                 padding: 5px 10px;
 
                 a {

--- a/scss/_themes.scss
+++ b/scss/_themes.scss
@@ -36,19 +36,19 @@ $material-brown-hl: #4e342e;
 $material-brown-fg: #fff;
 
 // ******* default dark *******
-.luxbar-menu-dark,
-.luxbar-menu-dark .dropdown ul {
+.#{$luxbar-css-prefix}-menu-dark,
+.#{$luxbar-css-prefix}-menu-dark .dropdown ul {
     background-color: $dark-bg;
     color: $dark-fg;
 }
 
-.luxbar-menu-dark {
+.#{$luxbar-css-prefix}-menu-dark {
     .active,
-    .luxbar-item:hover {
+    .#{$luxbar-css-prefix}-item:hover {
         background-color: $dark-hl;
     }
 
-    .luxbar-hamburger {
+    .#{$luxbar-css-prefix}-hamburger {
         span,
         span::before,
         span::after {
@@ -58,19 +58,19 @@ $material-brown-fg: #fff;
 }
 
 // ******* default light *******
-.luxbar-menu-light,
-.luxbar-menu-light .dropdown ul {
+.#{$luxbar-css-prefix}-menu-light,
+.#{$luxbar-css-prefix}-menu-light .dropdown ul {
     background-color: $light-bg;
     color: $light-fg;
 }
 
-.luxbar-menu-light {
+.#{$luxbar-css-prefix}-menu-light {
     .active,
-    .luxbar-item:hover {
+    .#{$luxbar-css-prefix}-item:hover {
         background-color: $light-hl;
     }
 
-    .luxbar-hamburger {
+    .#{$luxbar-css-prefix}-hamburger {
         span,
         span::before,
         span::after {
@@ -80,19 +80,19 @@ $material-brown-fg: #fff;
 }
 
 // ******* default material-red *******
-.luxbar-menu-material-red,
-.luxbar-menu-material-red .dropdown ul {
+.#{$luxbar-css-prefix}-menu-material-red,
+.#{$luxbar-css-prefix}-menu-material-red .dropdown ul {
     background-color: $material-red-bg;
     color: $material-red-fg;
 }
 
-.luxbar-menu-material-red {
+.#{$luxbar-css-prefix}-menu-material-red {
     .active,
-    .luxbar-item:hover {
+    .#{$luxbar-css-prefix}-item:hover {
         background-color: $material-red-hl;
     }
 
-    .luxbar-hamburger {
+    .#{$luxbar-css-prefix}-hamburger {
         span,
         span::before,
         span::after {
@@ -102,19 +102,19 @@ $material-brown-fg: #fff;
 }
 
 // ******* default material-indigo *******
-.luxbar-menu-material-indigo,
-.luxbar-menu-material-indigo .dropdown ul {
+.#{$luxbar-css-prefix}-menu-material-indigo,
+.#{$luxbar-css-prefix}-menu-material-indigo .dropdown ul {
     background-color: $material-indigo-bg;
     color: $material-indigo-fg;
 }
 
-.luxbar-menu-material-indigo {
+.#{$luxbar-css-prefix}-menu-material-indigo {
     .active,
-    .luxbar-item:hover {
+    .#{$luxbar-css-prefix}-item:hover {
         background-color: $material-indigo-hl;
     }
 
-    .luxbar-hamburger {
+    .#{$luxbar-css-prefix}-hamburger {
         span,
         span::before,
         span::after {
@@ -124,19 +124,19 @@ $material-brown-fg: #fff;
 }
 
 // ******* default material-green *******
-.luxbar-menu-material-green,
-.luxbar-menu-material-green .dropdown ul {
+.#{$luxbar-css-prefix}-menu-material-green,
+.#{$luxbar-css-prefix}-menu-material-green .dropdown ul {
     background-color: $material-green-bg;
     color: $material-green-fg;
 }
 
-.luxbar-menu-material-green {
+.#{$luxbar-css-prefix}-menu-material-green {
     .active,
-    .luxbar-item:hover {
+    .#{$luxbar-css-prefix}-item:hover {
         background-color: $material-green-hl;
     }
 
-    .luxbar-hamburger {
+    .#{$luxbar-css-prefix}-hamburger {
         span,
         span::before,
         span::after {
@@ -146,19 +146,19 @@ $material-brown-fg: #fff;
 }
 
 // ******* default material-amber *******
-.luxbar-menu-material-amber,
-.luxbar-menu-material-amber .dropdown ul {
+.#{$luxbar-css-prefix}-menu-material-amber,
+.#{$luxbar-css-prefix}-menu-material-amber .dropdown ul {
     background-color: $material-amber-bg;
     color: $material-amber-fg;
 }
 
-.luxbar-menu-material-amber {
+.#{$luxbar-css-prefix}-menu-material-amber {
     .active,
-    .luxbar-item:hover {
+    .#{$luxbar-css-prefix}-item:hover {
         background-color: $material-amber-hl;
     }
 
-    .luxbar-hamburger {
+    .#{$luxbar-css-prefix}-hamburger {
         span,
         span::before,
         span::after {
@@ -168,19 +168,19 @@ $material-brown-fg: #fff;
 }
 
 // ******* default material-brown *******
-.luxbar-menu-material-brown,
-.luxbar-menu-material-brown .dropdown ul {
+.#{$luxbar-css-prefix}-menu-material-brown,
+.#{$luxbar-css-prefix}-menu-material-brown .dropdown ul {
     background-color: $material-brown-bg;
     color: $material-brown-fg;
 }
 
-.luxbar-menu-material-brown {
+.#{$luxbar-css-prefix}-menu-material-brown {
     .active,
-    .luxbar-item:hover {
+    .#{$luxbar-css-prefix}-item:hover {
         background-color: $material-brown-hl;
     }
 
-    .luxbar-hamburger {
+    .#{$luxbar-css-prefix}-hamburger {
         span,
         span::before,
         span::after {
@@ -190,19 +190,19 @@ $material-brown-fg: #fff;
 }
 
 // ******* default material-bluegrey *******
-.luxbar-menu-material-bluegrey,
-.luxbar-menu-material-bluegrey .dropdown ul {
+.#{$luxbar-css-prefix}-menu-material-bluegrey,
+.#{$luxbar-css-prefix}-menu-material-bluegrey .dropdown ul {
     background-color: $material-bluegrey-bg;
     color: $material-bluegrey-fg;
 }
 
-.luxbar-menu-material-bluegrey {
+.#{$luxbar-css-prefix}-menu-material-bluegrey {
     .active,
-    .luxbar-item:hover {
+    .#{$luxbar-css-prefix}-item:hover {
         background-color: $material-bluegrey-hl;
     }
 
-    .luxbar-hamburger {
+    .#{$luxbar-css-prefix}-hamburger {
         span,
         span::before,
         span::after {
@@ -212,19 +212,19 @@ $material-brown-fg: #fff;
 }
 
 // ******* default material-cyan *******
-.luxbar-menu-material-cyan,
-.luxbar-menu-material-cyan .dropdown ul {
+.#{$luxbar-css-prefix}-menu-material-cyan,
+.#{$luxbar-css-prefix}-menu-material-cyan .dropdown ul {
     background-color: $material-cyan-bg;
     color: $material-cyan-fg;
 }
 
-.luxbar-menu-material-cyan {
+.#{$luxbar-css-prefix}-menu-material-cyan {
     .active,
-    .luxbar-item:hover {
+    .#{$luxbar-css-prefix}-item:hover {
         background-color: $material-cyan-hl;
     }
 
-    .luxbar-hamburger {
+    .#{$luxbar-css-prefix}-hamburger {
         span,
         span::before,
         span::after {


### PR DESCRIPTION
People can have really unique named menus so this change allows them to use their own class names with luxbar. Useful for example with WordPress projects.